### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,10 +12,10 @@ SP_LPS22HB	KEYWORD1
 # Methods and Functions (KEYWORD2)
 ##################################################################
 
-begin KEYWORD2
-whoAmI KEYWORD2
+begin	KEYWORD2
+whoAmI	KEYWORD2
 
-readTemperature KEYWORD2
-readPressure KEYWORD2
-readPressureRAW KEYWORD2
-readPressureUI KEYWORD2
+readTemperature	KEYWORD2
+readPressure	KEYWORD2
+readPressureRAW	KEYWORD2
+readPressureUI	KEYWORD2


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords